### PR TITLE
Modern cyberpunk redesign

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,9 @@
         continue.</strong
       >
     </noscript>
+    <div id="loading-screen" class="loading-screen">
+      <div class="spinner"></div>
+    </div>
     <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app" class="d-flex flex-column">
-    <NavSite class="col-12 custom-h"></NavSite>
+    <NavSite class="col-12"></NavSite>
 
     <router-view class="col-12" />
   </div>
@@ -27,8 +27,4 @@ export default {
   text-align: center;
 }
 
-.custom-h {
-  background-image: linear-gradient(90deg, #000428, #004e92);
-  filter: drop-shadow(2px 4px 6px #000);
-}
 </style>

--- a/src/assets/scss/portfolio.scss
+++ b/src/assets/scss/portfolio.scss
@@ -6,9 +6,10 @@
 }
 
 .zoom-effect {
-  transition: 0.2s;
+  transition: transform 0.3s, box-shadow 0.3s;
   &:hover {
     z-index: 4;
-    transform: scale(1.2);
+    transform: scale(1.15);
+    box-shadow: 0 0 15px #7f00ff;
   }
 }

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -1,11 +1,14 @@
 .hello {
-  background-color: rgb(62, 62, 62);
+  background-color: transparent;
 }
 
 body {
   font-family: "Orbitron", "Inter", "Poppins", Arial, sans-serif;
-  background-color: #0a0a0a;
+  background-color: #050008;
+  background-image: radial-gradient(circle at top left, rgba(255, 0, 102, 0.2), transparent 60%),
+    radial-gradient(circle at bottom right, rgba(127, 0, 255, 0.2), transparent 60%);
   color: #e4e4e4;
+  overflow-x: hidden;
 }
 
 /* neon style backgrounds */
@@ -36,17 +39,17 @@ body {
 }
 
 ::-webkit-scrollbar {
-  width: 20px;
+  width: 12px;
 }
 
 ::-webkit-scrollbar-track {
-  background-color: #050505;
+  background-color: #141414;
 }
 
 ::-webkit-scrollbar-thumb {
   border-radius: 100px;
-  background-image: linear-gradient(0deg, #ff5858 0%, #f09819 100%);
-  box-shadow: inset 2px 2px 5px 0 rgba(rgb(0, 0, 0), 0.5);
+  background-image: linear-gradient(180deg, #ff0066, #7f00ff);
+  box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.7);
 }
 
 /* neon glow utility */
@@ -58,4 +61,80 @@ body {
 /* small helper to limit width */
 .max-w-600 {
   max-width: 600px;
+}
+
+/* generic section container */
+.cyber-section {
+  border: 2px solid #ff0066;
+  border-radius: 8px;
+  box-shadow: 0 0 20px rgba(255, 0, 102, 0.4), 0 0 40px rgba(127, 0, 255, 0.3);
+  margin-bottom: 3rem;
+  position: relative;
+  overflow: hidden;
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    box-shadow: 0 0 10px #ff0066 inset, 0 0 20px #7f00ff inset;
+    opacity: 0.5;
+    animation: sectionGlow 3s ease-in-out infinite alternate;
+    pointer-events: none;
+  }
+}
+
+@keyframes sectionGlow {
+  from {
+    opacity: 0.3;
+  }
+  to {
+    opacity: 0.8;
+  }
+}
+
+/* navigation */
+.cyber-nav {
+  background-image: linear-gradient(90deg, #330033 0%, #000428 100%);
+  padding: 0.5rem 2rem;
+  box-shadow: 0 0 10px #ff0066;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  .nav-link,
+  router-link {
+    color: #e4e4e4;
+    text-transform: uppercase;
+    transition: color 0.3s ease, text-shadow 0.3s ease;
+    &:hover {
+      color: #40ff00;
+      text-shadow: 0 0 5px #40ff00, 0 0 10px #40ff00;
+    }
+  }
+}
+
+/* loading screen */
+.loading-screen {
+  position: fixed;
+  inset: 0;
+  background-color: #050008;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.spinner {
+  width: 60px;
+  height: 60px;
+  border: 5px solid transparent;
+  border-top-color: #ff0066;
+  border-right-color: #7f00ff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/src/components/AboutElement.vue
+++ b/src/components/AboutElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="about" class="p-5 bg-custom2" data-aos="fade-up">
+  <div id="about" class="p-5 bg-custom2 cyber-section" data-aos="fade-up">
     <div class="container text-center">
       <h2 class="display-3 fw-bold text-white">About Me</h2>
       <p class="lead text-white">

--- a/src/components/ContactElement.vue
+++ b/src/components/ContactElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="contact" class="p-5 bg-custom" data-aos="fade-up">
+  <div id="contact" class="p-5 bg-custom cyber-section" data-aos="fade-up">
     <div class="container text-center">
       <h2 class="display-3 fw-bold text-white pb-3">Contact</h2>
       <p class="lead text-white">Email : lele19977@gmail.com</p>

--- a/src/components/ExperienceElement.vue
+++ b/src/components/ExperienceElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="experience" class="p-5 bg-custom3" data-aos="fade-up">
+  <div id="experience" class="p-5 bg-custom3 cyber-section" data-aos="fade-up">
     <div class="container text-center">
       <h2 class="display-3 fw-bold text-white pb-3">Experience</h2>
       <p class="lead text-white">A quick overview of my recent journey.</p>

--- a/src/components/JumboElement.vue
+++ b/src/components/JumboElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="home" class="p-5 bg-custom">
+  <div id="home" class="p-5 bg-custom cyber-section">
     <div class="container text-center">
       <h2 class="display-3 fw-bold text-white cyber-glow">
         <em>Gabriele Pini</em>

--- a/src/components/NavSite.vue
+++ b/src/components/NavSite.vue
@@ -1,39 +1,28 @@
 <template>
-  <div>
-    <nav
-      class="navbar d-flex justify-content-center align-items-center navbar-dark bg-darker container"
-      data-aos="fade-down"
-    >
-      <div class="logo">
-        <router-link to="/"
-          ><img class="img-fluid" src="@/assets/img/avatar.png" alt=""
-        /></router-link>
-      </div>
-      <div class="container d-flex justify-content-center">
-        <div>
-          <ul
-            class="navbar-nav d-flex flex-row mt-2 flex-wrap justify-content-center align-items-center"
-          >
-            <li class="nav-item p-2" v-if="isHome">
-              <a class="nav-link" href="#about">About</a>
-            </li>
-            <li class="nav-item p-2" v-if="isHome">
-              <a class="nav-link" href="#skills">Skills</a>
-            </li>
-            <li class="nav-item p-2" v-if="isHome">
-              <a class="nav-link" href="#portfolio">Portfolio</a>
-            </li>
-            <li class="nav-item p-2" v-if="isHome">
-              <a class="nav-link" href="#contact">Contact</a>
-            </li>
-            <li class="nav-item p-3">
-              <router-link to="/Game" class="decoration-none">Game</router-link>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-  </div>
+  <nav class="cyber-nav d-flex align-items-center" data-aos="fade-down">
+    <div class="logo me-4">
+      <router-link to="/"
+        ><img class="img-fluid" src="@/assets/img/avatar.png" alt=""
+      /></router-link>
+    </div>
+    <ul class="list-unstyled d-flex flex-row m-0 ms-auto">
+      <li class="p-2" v-if="isHome">
+        <a class="nav-link" href="#about">About</a>
+      </li>
+      <li class="p-2" v-if="isHome">
+        <a class="nav-link" href="#skills">Skills</a>
+      </li>
+      <li class="p-2" v-if="isHome">
+        <a class="nav-link" href="#portfolio">Portfolio</a>
+      </li>
+      <li class="p-2" v-if="isHome">
+        <a class="nav-link" href="#contact">Contact</a>
+      </li>
+      <li class="p-2">
+        <router-link to="/Game" class="decoration-none">Game</router-link>
+      </li>
+    </ul>
+  </nav>
 </template>
 
 <script>
@@ -61,21 +50,21 @@ export default {
   background-image: linear-gradient(-60deg, #ff0066 0%, #7f00ff 100%);
 }
 
-.navbar {
-  position: sticky;
-  top: 3%;
-  a {
-    font-weight: bold;
-    &:hover {
-      color: #00ffff;
-    }
+.nav-link {
+  text-decoration: none;
+  position: relative;
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -4px;
+    width: 0;
+    height: 2px;
+    background: #40ff00;
+    transition: width 0.3s;
   }
-
-  router-link {
-    font-weight: bold;
-    &:hover {
-      color: #00ffff;
-    }
+  &:hover::after {
+    width: 100%;
   }
 }
 

--- a/src/components/PortfolioElement.vue
+++ b/src/components/PortfolioElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="portfolio" class="p-5 bg-custom2" data-aos="fade-up">
+  <div id="portfolio" class="p-5 bg-custom2 cyber-section" data-aos="fade-up">
     <div class="container text-center">
       <h2 class="display-3 fw-bold text-white pb-3">Portfolio</h2>
       <div class="container bg-custom">

--- a/src/components/SkillsElement.vue
+++ b/src/components/SkillsElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="skills" class="p-5 bg-custom" data-aos="fade-up">
+  <div id="skills" class="p-5 bg-custom cyber-section" data-aos="fade-up">
     <h2 class="display-3 fw-bold text-white">Skills</h2>
     <div class="container bg-custom2">
       <div class="container__progressbars">

--- a/src/main.js
+++ b/src/main.js
@@ -32,4 +32,8 @@ AOS.init();
 new Vue({
   router,
   render: (h) => h(App),
+  mounted() {
+    const loader = document.getElementById("loading-screen");
+    if (loader) loader.style.display = "none";
+  },
 }).$mount("#app");


### PR DESCRIPTION
## Summary
- overhaul page backgrounds, scrollbars and section styling
- redesign navigation to cyberpunk look with neon hover effects
- add portfolio hover glow
- wrap sections in new cyberpunk container
- include loading screen and hide it when the app mounts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68597d8c9218832b83773a5e67be317b